### PR TITLE
Fix: Normalize composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "adipriyantobpn/yii2-composer-helper",
-    "description": "Composer helper for Yii2",
     "type": "yii2-extension",
+    "description": "Composer helper for Yii2",
     "keywords": [
         "yii2",
         "extension",
@@ -17,16 +17,16 @@
             "email": "adipriyanto.bpn@gmail.com"
         }
     ],
-    "minimum-stability": "dev",
     "require": {
         "yiisoft/yii2": "*"
+    },
+    "extra": {
+        "bootstrap": "adipriyantobpn\\composer\\Bootstrap"
     },
     "autoload": {
         "psr-4": {
             "adipriyantobpn\\composer\\": ""
         }
     },
-    "extra": {
-        "bootstrap": "adipriyantobpn\\composer\\Bootstrap"
-    }
+    "minimum-stability": "dev"
 }


### PR DESCRIPTION
This PR

* [x] normalizes `composer.json`

Follows d2bc1029d95d1480c59f628e7384785c52dd606c.

💁‍♂️ Ran

```
$ composer global require localheinz/composer-normalize
```

and then

```
$ composer normalize
```

For reference, see [`localheinz/composer-normalize`](https://github.com/localheinz/composer-normalize).